### PR TITLE
feat: add Salary Calculator link to multiple pages and sidebar

### DIFF
--- a/calculadora-salario.html
+++ b/calculadora-salario.html
@@ -1,0 +1,756 @@
+<!DOCTYPE html>
+<html lang="es" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Finx - Calculadora de Salario Neto</title>
+    <meta name="description" content="Calcula tu salario neto estimado en Panamá después de CSS, Seguro Educativo e ISR con la herramienta educativa de FINX.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="trivia/shared-sidebar.css">
+    <link rel="stylesheet" href="css/calculadora-salario.css">
+    <style>
+        .trivia-navbar {
+            background-color: var(--background-color) !important;
+            box-shadow: 0 2px 15px rgba(0, 0, 0, 0.1);
+            padding: 0.75rem 0;
+            min-height: 95px;
+        }
+
+        .navbar-logo-container {
+            display: flex;
+            align-items: center;
+            margin-right: 0.5rem;
+        }
+
+        .navbar-logo {
+            max-height: 80px;
+            height: auto;
+        }
+
+        .navbar-logo-light { display: block; }
+        .navbar-logo-dark { display: none; }
+        [data-bs-theme="dark"] .navbar-logo-light { display: none; }
+        [data-bs-theme="dark"] .navbar-logo-dark { display: block; }
+
+        .trivia-theme-toggle {
+            background: none;
+            border: none;
+            color: var(--text-color);
+            font-size: 1.3rem;
+            cursor: pointer;
+            padding: 0.4rem 0.6rem;
+            border-radius: 50%;
+            transition: background 0.2s ease;
+        }
+
+        .trivia-theme-toggle:hover {
+            background: rgba(29, 72, 138, 0.1);
+        }
+
+        .user-profile-navbar {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.5rem 1rem;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 50px;
+            border: 1px solid rgba(0, 0, 0, 0.08);
+            cursor: pointer;
+            position: relative;
+        }
+
+        .avatar-small {
+            width: 40px;
+            height: 40px;
+            background: linear-gradient(135deg, #1D488A, #91A9CC);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+        }
+
+        .user-info-small {
+            display: flex;
+            flex-direction: column;
+            line-height: 1.2;
+        }
+
+        .user-name { font-weight: 600; font-size: 0.9rem; color: #333; margin: 0; }
+        .user-level { font-size: 0.75rem; color: #666; margin: 0; }
+        [data-bs-theme="dark"] .user-name { color: #fff; }
+        [data-bs-theme="dark"] .user-level { color: rgba(255,255,255,0.7); }
+
+        .user-dropdown-menu {
+            position: absolute;
+            top: 100%;
+            right: 0;
+            width: 280px;
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+            opacity: 0;
+            visibility: hidden;
+            transform: translateY(-10px);
+            transition: all 0.3s ease;
+            z-index: 9999;
+            margin-top: 8px;
+            pointer-events: none;
+        }
+
+        .user-profile-navbar.open .user-dropdown-menu {
+            opacity: 1;
+            visibility: visible;
+            transform: translateY(0);
+            pointer-events: auto;
+        }
+
+        .dropdown-header {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 16px 20px;
+            background: #f8f9fa;
+            border-bottom: 1px solid rgba(0,0,0,0.05);
+        }
+
+        .dropdown-avatar {
+            width: 48px;
+            height: 48px;
+            background: linear-gradient(135deg, #1D488A, #91A9CC);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 1.4rem;
+        }
+
+        .dropdown-user-name { font-weight: 700; color: #333; }
+        .dropdown-user-level { font-size: 0.8rem; color: #666; }
+        .dropdown-divider { height: 1px; background: #eee; margin: 0.25rem 0; }
+
+        .dropdown-item {
+            display: block;
+            padding: 0.75rem 1.25rem;
+            color: #333;
+            text-decoration: none;
+        }
+
+        .dropdown-item:hover { background: #f1f3f5; }
+        .dropdown-item-content { display: flex; align-items: center; gap: 0.75rem; }
+        .dropdown-item-danger { color: #dc3545; }
+
+        [data-bs-theme="dark"] .user-dropdown-menu { background: #1e2a3a; }
+        [data-bs-theme="dark"] .dropdown-header { background: #162033; }
+        [data-bs-theme="dark"] .dropdown-user-name,
+        [data-bs-theme="dark"] .dropdown-item { color: #f3f4f6; }
+        [data-bs-theme="dark"] .dropdown-item:hover { background: #243447; }
+
+        .trivia-sidebar.hidden,
+        .leccion-sidebar.hidden {
+            transform: translateX(-100%);
+        }
+
+        .sidebar-toggle-btn {
+            position: fixed;
+            left: 280px;
+            top: 50%;
+            transform: translateY(-50%);
+            background: linear-gradient(135deg, #1D488A, #91A9CC);
+            border: none;
+            color: white;
+            width: 40px;
+            height: 60px;
+            border-radius: 0 15px 15px 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.2rem;
+            transition: all 0.3s ease;
+            box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
+            cursor: pointer;
+            z-index: 1000;
+        }
+
+        .sidebar-toggle-btn:hover {
+            background: linear-gradient(135deg, #91A9CC, #1D488A);
+            transform: translateY(-50%) translateX(5px);
+        }
+
+        .sidebar-toggle-btn.sidebar-hidden {
+            left: 0;
+        }
+
+        .main-content {
+            margin-left: 280px;
+            padding: 1.5rem;
+            min-height: 100vh;
+            transition: margin-left 0.3s ease, width 0.3s ease;
+        }
+
+        .main-content.sidebar-hidden {
+            margin-left: 0;
+            width: 100%;
+        }
+
+        @media (max-width: 991.98px) {
+            .main-content {
+                margin-left: 0;
+                padding: 1rem;
+                width: 100%;
+            }
+
+            .sidebar-toggle-btn {
+                left: 0;
+            }
+
+            .user-info-small {
+                display: none;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .navbar-logo { max-height: 65px; }
+        }
+
+        @media (max-width: 576px) {
+            .navbar-logo { max-height: 55px; }
+        }
+    </style>
+</head>
+<body>
+    <!-- Navbar (mismo patrón del dashboard) -->
+    <nav class="navbar trivia-navbar">
+        <div class="container-fluid">
+            <div class="d-flex align-items-center justify-content-between w-100">
+                <div style="flex:1; display:flex; align-items:center; gap: 1rem;">
+                    <div class="navbar-logo-container">
+                        <img src="images/modo-claro.png" alt="Finx Logo" class="navbar-logo navbar-logo-light">
+                        <img src="images/modo-oscuro.png" alt="Finx Logo" class="navbar-logo navbar-logo-dark">
+                    </div>
+                </div>
+                <div style="flex:1; display:flex; justify-content:end; align-items:center; gap: 1rem;">
+                    <button class="trivia-theme-toggle" id="langToggle" title="Traducir página" type="button">
+                        <i class="bi bi-translate"></i>
+                    </button>
+                    <button class="trivia-theme-toggle" id="themeToggle" title="Cambiar tema" type="button">
+                        <i class="bi bi-moon-fill" id="themeIcon"></i>
+                    </button>
+                    <div class="user-profile-navbar">
+                        <div class="avatar-small">
+                            <i class="bi bi-person-fill"></i>
+                        </div>
+                        <div class="user-info-small">
+                            <span class="user-name">Usuario</span>
+                            <small class="user-level">Nivel 2</small>
+                        </div>
+                        <div class="user-dropdown-menu">
+                            <div class="dropdown-header">
+                                <div class="dropdown-avatar">
+                                    <i class="bi bi-person-fill"></i>
+                                </div>
+                                <div class="dropdown-user-info">
+                                    <span class="dropdown-user-name">Usuario</span>
+                                    <small class="dropdown-user-level">Nivel 2</small>
+                                </div>
+                            </div>
+                            <div class="dropdown-divider"></div>
+                            <a href="profile.html" class="dropdown-item">
+                                <div class="dropdown-item-content">
+                                    <i class="bi bi-person-circle"></i>
+                                    <span>Mi Perfil</span>
+                                </div>
+                            </a>
+                            <a href="#" class="dropdown-item">
+                                <div class="dropdown-item-content">
+                                    <i class="bi bi-gear"></i>
+                                    <span>Configuración</span>
+                                </div>
+                            </a>
+                            <a href="#" class="dropdown-item">
+                                <div class="dropdown-item-content">
+                                    <i class="bi bi-shield-check"></i>
+                                    <span>Privacidad</span>
+                                </div>
+                            </a>
+                            <div class="dropdown-divider"></div>
+                            <a href="#" class="dropdown-item dropdown-item-danger" id="logoutBtnNavbar">
+                                <div class="dropdown-item-content">
+                                    <i class="bi bi-box-arrow-right"></i>
+                                    <span>Cerrar Sesión</span>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Sidebar del dashboard -->
+    <nav class="leccion-sidebar trivia-sidebar" data-sidebar-version="1">
+        <div class="container-fluid">
+            <div class="sidebar-logo-container text-center mb-3">
+                <img src="images/modo-claro.png" alt="Finx Logo" class="sidebar-logo sidebar-logo-light">
+                <img src="images/modo-oscuro.png" alt="Finx Logo" class="sidebar-logo sidebar-logo-dark">
+            </div>
+            <ul class="sidebar-nav">
+                <li>
+                    <a href="dashboard.html">
+                        <i class="bi bi-house-door-fill"></i>
+                        <span>Management</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="trivia/trivia.html">
+                        <i class="bi bi-book-fill"></i>
+                        <span>Lessons</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="trivia/logros.html">
+                        <i class="bi bi-trophy-fill"></i>
+                        <span>Achievements</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="goals.html">
+                        <i class="bi bi-flag-fill"></i>
+                        <span>Goals</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="calculadora-salario.html" class="active">
+                        <i class="bi bi-calculator-fill"></i>
+                        <span>Salary Calculator</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="helpcenter2.html">
+                        <i class="bi bi-question-circle-fill"></i>
+                        <span>Help</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="chatbot.html">
+                        <i class="bi bi-robot"></i>
+                        <span>Assistant</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </nav>
+
+    <button class="sidebar-toggle-btn" id="sidebarToggle" type="button" aria-label="Mostrar u ocultar menú">
+        <i class="bi bi-chevron-left"></i>
+    </button>
+
+    <!-- Contenido principal -->
+    <main class="main-content">
+        <div class="salary-page">
+            <header class="salary-hero">
+                <span class="badge-finx">
+                    <i class="bi bi-calculator"></i> Herramienta FINX
+                </span>
+                <h1>Calculadora de Salario Neto</h1>
+                <p class="lead">
+                    Calcula cuánto recibirás realmente después de impuestos y deducciones en Panamá.
+                </p>
+            </header>
+
+            <div class="salary-layout">
+                <section class="salary-card" aria-labelledby="formTitle">
+                    <h2 id="formTitle">Tus datos salariales</h2>
+                    <p class="card-subtitle">
+                        Completa el formulario para obtener una estimación de tu salario neto mensual.
+                    </p>
+
+                    <form id="salaryForm" novalidate>
+                        <div class="mb-3">
+                            <label class="form-label" for="salarioBruto" id="salarioLabel">Salario bruto mensual (B/.)</label>
+                            <input
+                                type="number"
+                                class="form-control"
+                                id="salarioBruto"
+                                name="salarioBruto"
+                                min="0.01"
+                                step="0.01"
+                                inputmode="decimal"
+                                required
+                                aria-describedby="salarioHint error-salarioBruto"
+                                placeholder="Ej: 1500.00"
+                            >
+                            <span class="field-hint" id="salarioHint">Ingresa tu salario bruto antes de deducciones.</span>
+                            <span class="field-error" id="error-salarioBruto" role="alert"></span>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label" for="frecuencia">Frecuencia de pago</label>
+                            <select class="form-select" id="frecuencia" name="frecuencia" aria-describedby="frecuenciaHint">
+                                <option value="mensual" selected>Mensual</option>
+                                <option value="quincenal">Quincenal</option>
+                            </select>
+                            <span class="field-hint" id="frecuenciaHint">Si eliges quincenal, el monto se convertirá a equivalente mensual.</span>
+                        </div>
+
+                        <fieldset class="mb-3">
+                            <legend class="form-label">¿Desea incluir el cálculo del décimo tercer mes?</legend>
+                            <div class="option-group" role="radiogroup" aria-label="Incluir décimo tercer mes">
+                                <div class="option-chip">
+                                    <input type="radio" id="incluirDecimoNo" name="incluirDecimo" value="no" checked>
+                                    <label for="incluirDecimoNo"><i class="bi bi-x-circle"></i> No</label>
+                                </div>
+                                <div class="option-chip">
+                                    <input type="radio" id="incluirDecimoSi" name="incluirDecimo" value="si">
+                                    <label for="incluirDecimoSi"><i class="bi bi-check-circle"></i> Sí</label>
+                                </div>
+                            </div>
+                        </fieldset>
+
+                        <div class="decimo-panel" id="decimoOptions" hidden aria-hidden="true">
+                            <p class="field-hint mb-2">
+                                El décimo tercer mes corresponde a una prestación laboral pagada en tres partidas durante el año.
+                                No asumimos que trabajaste todo el período: indica el salario acumulado del período correspondiente.
+                            </p>
+                            <label class="form-label" for="salarioAcumulado">Salario acumulado del período (B/.)</label>
+                            <input
+                                type="number"
+                                class="form-control"
+                                id="salarioAcumulado"
+                                name="salarioAcumulado"
+                                min="0.01"
+                                step="0.01"
+                                inputmode="decimal"
+                                placeholder="Ej: 6000.00"
+                                aria-describedby="acumuladoHint error-salarioAcumulado"
+                            >
+                            <span class="field-hint" id="acumuladoHint">Suma de salarios brutos recibidos en el período del décimo (aprox. 4 meses).</span>
+                            <span class="field-error" id="error-salarioAcumulado" role="alert"></span>
+                        </div>
+
+                        <div class="mb-3 mt-3">
+                            <label class="form-label" for="otrosDescuentos">Otros descuentos voluntarios (B/.)</label>
+                            <input
+                                type="number"
+                                class="form-control"
+                                id="otrosDescuentos"
+                                name="otrosDescuentos"
+                                min="0"
+                                step="0.01"
+                                inputmode="decimal"
+                                placeholder="Ej: 50.00 (opcional)"
+                                aria-describedby="otrosHint error-otrosDescuentos"
+                            >
+                            <span class="field-hint" id="otrosHint">Opcional. Préstamos, seguros privados u otros descuentos mensuales.</span>
+                            <span class="field-error" id="error-otrosDescuentos" role="alert"></span>
+                        </div>
+
+                        <div class="form-actions">
+                            <button type="submit" class="btn btn-salary-primary" id="btnCalcular">
+                                <i class="bi bi-calculator me-1"></i> Calcular mi salario
+                            </button>
+                            <button type="button" class="btn btn-salary-secondary" id="btnClear">
+                                <i class="bi bi-eraser me-1"></i> Limpiar
+                            </button>
+                        </div>
+                    </form>
+                </section>
+
+                <section
+                    class="salary-card results-section"
+                    id="resultsSection"
+                    hidden
+                    aria-live="polite"
+                    aria-atomic="true"
+                    aria-labelledby="resultsTitle"
+                >
+                    <h2 id="resultsTitle">Resultados</h2>
+                    <p class="card-subtitle">Estimación referencial con base en las deducciones obligatorias principales.</p>
+
+                    <div class="net-highlight">
+                        <div class="net-label">Tu salario neto estimado</div>
+                        <div class="net-value" id="netSalaryValue">B/. 0.00</div>
+                        <div class="net-note">Monto aproximado que podrías recibir al mes</div>
+                    </div>
+
+                    <p class="conversion-note" id="conversionNote" hidden></p>
+
+                    <ul class="breakdown-list" aria-label="Desglose de salario">
+                        <li>
+                            <span class="breakdown-item"><span class="emoji" aria-hidden="true">💰</span> Salario bruto</span>
+                            <span class="breakdown-value" id="resultBruto">B/. 0.00</span>
+                        </li>
+                        <li>
+                            <span class="breakdown-item"><span class="emoji" aria-hidden="true">🏥</span> Seguro Social</span>
+                            <span class="breakdown-value deduction-value" id="resultCSS">− B/. 0.00</span>
+                        </li>
+                        <li>
+                            <span class="breakdown-item"><span class="emoji" aria-hidden="true">🎓</span> Seguro Educativo</span>
+                            <span class="breakdown-value deduction-value" id="resultSE">− B/. 0.00</span>
+                        </li>
+                        <li>
+                            <span class="breakdown-item"><span class="emoji" aria-hidden="true">📊</span> Impuesto Sobre la Renta</span>
+                            <span class="breakdown-value deduction-value" id="resultISR">− B/. 0.00</span>
+                        </li>
+                        <li>
+                            <span class="breakdown-item"><span class="emoji" aria-hidden="true">📌</span> Otros descuentos</span>
+                            <span class="breakdown-value deduction-value" id="resultOtros">− B/. 0.00</span>
+                        </li>
+                        <li>
+                            <span class="breakdown-item"><span class="emoji" aria-hidden="true">💵</span> Salario neto</span>
+                            <span class="breakdown-value" id="resultNeto">B/. 0.00</span>
+                        </li>
+                    </ul>
+
+                    <div class="summary-stats">
+                        <div class="stat-box">
+                            <span class="stat-label">Total de deducciones</span>
+                            <span class="stat-value" id="totalDeducciones">B/. 0.00</span>
+                        </div>
+                        <div class="stat-box">
+                            <span class="stat-label">Porcentaje de tu salario que se descuenta</span>
+                            <span class="stat-value" id="porcentajeDeducciones">0.00%</span>
+                        </div>
+                    </div>
+
+                    <div class="salary-bar-wrap">
+                        <div class="salary-bar-title">Distribución visual del salario</div>
+                        <div class="salary-bar" role="img" aria-label="Barra de distribución del salario bruto">
+                            <span class="bar-neto" id="barNeto" style="width:0%" title="Salario neto"></span>
+                            <span class="bar-css" id="barCSS" style="width:0%" title="CSS"></span>
+                            <span class="bar-se" id="barSE" style="width:0%" title="Seguro Educativo"></span>
+                            <span class="bar-isr" id="barISR" style="width:0%" title="ISR"></span>
+                            <span class="bar-otros" id="barOtros" style="width:0%" title="Otros"></span>
+                        </div>
+                        <div class="bar-legend">
+                            <span><i class="legend-neto"></i> Neto</span>
+                            <span><i class="legend-css"></i> CSS</span>
+                            <span><i class="legend-se"></i> Seguro Educativo</span>
+                            <span><i class="legend-isr"></i> ISR</span>
+                            <span><i class="legend-otros"></i> Otros</span>
+                        </div>
+                    </div>
+
+                    <div class="isr-explain">
+                        <h3>Cómo se estimó el ISR</h3>
+                        <p class="mb-1">Se proyecta el ingreso anual y se aplica la tarifa progresiva; luego se divide entre 12 para obtener la retención mensual estimada.</p>
+                        <ul>
+                            <li>Ingreso anual estimado: <strong id="isrIngresoAnual">B/. 0.00</strong></li>
+                            <li>ISR anual estimado: <strong id="isrAnual">B/. 0.00</strong></li>
+                            <li>ISR mensual estimado: <strong id="isrMensualDetalle">B/. 0.00</strong></li>
+                        </ul>
+                    </div>
+
+                    <div class="decimo-results" id="decimoResults" hidden>
+                        <h3>Estimación del décimo tercer mes</h3>
+                        <p class="field-hint mb-3">
+                            El décimo tercer mes corresponde a una prestación laboral pagada en tres partidas durante el año.
+                            Estimación: salario acumulado ÷ 12, menos CSS (9.75%) y Seguro Educativo (1.25%).
+                        </p>
+                        <ul class="breakdown-list">
+                            <li>
+                                <span class="breakdown-item">Décimo bruto estimado</span>
+                                <span class="breakdown-value" id="decimoBruto">B/. 0.00</span>
+                            </li>
+                            <li>
+                                <span class="breakdown-item">CSS sobre el décimo</span>
+                                <span class="breakdown-value deduction-value" id="decimoCSS">− B/. 0.00</span>
+                            </li>
+                            <li>
+                                <span class="breakdown-item">Seguro Educativo sobre el décimo</span>
+                                <span class="breakdown-value deduction-value" id="decimoSE">− B/. 0.00</span>
+                            </li>
+                            <li>
+                                <span class="breakdown-item">Deducciones aplicables</span>
+                                <span class="breakdown-value deduction-value" id="decimoDeducciones">B/. 0.00</span>
+                            </li>
+                            <li>
+                                <span class="breakdown-item">Décimo neto estimado</span>
+                                <span class="breakdown-value" id="decimoNeto">B/. 0.00</span>
+                            </li>
+                        </ul>
+                    </div>
+
+                    <p class="disclaimer">
+                        <i class="bi bi-info-circle me-1"></i>
+                        Esta calculadora ofrece una <strong>estimación referencial</strong>. El cálculo real puede depender de tu situación fiscal,
+                        deducciones permitidas, tipo de contrato y la normativa vigente en Panamá.
+                    </p>
+                </section>
+            </div>
+
+            <section class="tips-section" aria-labelledby="tipsTitle">
+                <h2 id="tipsTitle">¿Sabías que?</h2>
+                <p class="tips-intro">Pequeños consejos para usar mejor tu salario neto.</p>
+                <div class="tips-grid">
+                    <article class="tip-card">
+                        <div class="tip-icon" aria-hidden="true"><i class="bi bi-wallet2"></i></div>
+                        <p>Tu salario bruto no es necesariamente el dinero que recibirás en tu cuenta.</p>
+                    </article>
+                    <article class="tip-card">
+                        <div class="tip-icon" aria-hidden="true"><i class="bi bi-pie-chart"></i></div>
+                        <p>Las deducciones reducen tu ingreso disponible.</p>
+                    </article>
+                    <article class="tip-card">
+                        <div class="tip-icon" aria-hidden="true"><i class="bi bi-journal-check"></i></div>
+                        <p>Conocer tu salario neto te ayuda a crear un presupuesto realista.</p>
+                    </article>
+                    <article class="tip-card">
+                        <div class="tip-icon" aria-hidden="true"><i class="bi bi-calendar-check"></i></div>
+                        <p>Antes de planificar tus gastos mensuales, utiliza tu salario neto como referencia.</p>
+                    </article>
+                </div>
+                <p class="finx-message">
+                    FINX te ayuda a entender mejor cómo se distribuye tu dinero para que puedas tomar decisiones financieras más informadas.
+                </p>
+            </section>
+        </div>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/calculadora-salario.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // Tema
+            const themeToggle = document.getElementById('themeToggle');
+            const themeIcon = document.getElementById('themeIcon');
+            const savedTheme = localStorage.getItem('theme') || 'light';
+            document.documentElement.setAttribute('data-bs-theme', savedTheme);
+            if (themeIcon) {
+                themeIcon.className = savedTheme === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-fill';
+            }
+
+            if (themeToggle) {
+                themeToggle.addEventListener('click', function () {
+                    const current = document.documentElement.getAttribute('data-bs-theme');
+                    const next = current === 'dark' ? 'light' : 'dark';
+                    document.documentElement.setAttribute('data-bs-theme', next);
+                    localStorage.setItem('theme', next);
+                    themeIcon.className = next === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-fill';
+                });
+            }
+
+            // Sidebar toggle
+            const sidebar = document.querySelector('.trivia-sidebar, .leccion-sidebar');
+            const toggleBtn = document.getElementById('sidebarToggle');
+            const mainContent = document.querySelector('.main-content');
+
+            if (toggleBtn && sidebar && mainContent) {
+                toggleBtn.addEventListener('click', function () {
+                    sidebar.classList.toggle('hidden');
+                    toggleBtn.classList.toggle('sidebar-hidden');
+                    mainContent.classList.toggle('sidebar-hidden');
+                    const icon = toggleBtn.querySelector('i');
+                    if (icon) {
+                        icon.classList.toggle('bi-chevron-left');
+                        icon.classList.toggle('bi-chevron-right');
+                    }
+                });
+            }
+
+            // Menú de perfil
+            const userProfile = document.querySelector('.user-profile-navbar');
+            if (userProfile) {
+                userProfile.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    userProfile.classList.toggle('open');
+                });
+                document.addEventListener('click', function (e) {
+                    if (!userProfile.contains(e.target)) {
+                        userProfile.classList.remove('open');
+                    }
+                });
+            }
+
+            // Logout
+            const logoutBtn = document.getElementById('logoutBtnNavbar');
+            if (logoutBtn) {
+                logoutBtn.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    window.location.href = 'index.html';
+                });
+            }
+
+            // Traducción básica del sidebar
+            const translations = {
+                es: {
+                    management: 'Gestión',
+                    lessons: 'Lecciones',
+                    achievements: 'Logros',
+                    goals: 'Metas',
+                    calculator: 'Calculadora',
+                    help: 'Ayuda',
+                    assistant: 'Asistente',
+                    user: 'Usuario',
+                    level: 'Nivel 2',
+                    profile: 'Mi Perfil',
+                    settings: 'Configuración',
+                    privacy: 'Privacidad',
+                    logout: 'Cerrar Sesión'
+                },
+                en: {
+                    management: 'Management',
+                    lessons: 'Lessons',
+                    achievements: 'Achievements',
+                    goals: 'Goals',
+                    calculator: 'Salary Calculator',
+                    help: 'Help',
+                    assistant: 'Assistant',
+                    user: 'User',
+                    level: 'Level 2',
+                    profile: 'My Profile',
+                    settings: 'Settings',
+                    privacy: 'Privacy',
+                    logout: 'Logout'
+                }
+            };
+
+            function setLanguage(lang) {
+                localStorage.setItem('finx_lang', lang);
+                const t = translations[lang] || translations.es;
+                const items = document.querySelectorAll('.sidebar-nav li span');
+                if (items.length >= 7) {
+                    items[0].textContent = t.management;
+                    items[1].textContent = t.lessons;
+                    items[2].textContent = t.achievements;
+                    items[3].textContent = t.goals;
+                    items[4].textContent = t.calculator;
+                    items[5].textContent = t.help;
+                    items[6].textContent = t.assistant;
+                }
+                document.querySelectorAll('.user-name, .dropdown-user-name').forEach((el) => {
+                    el.textContent = t.user;
+                });
+                document.querySelectorAll('.user-level, .dropdown-user-level').forEach((el) => {
+                    el.textContent = t.level;
+                });
+                const dropdownSpans = document.querySelectorAll('.dropdown-item span');
+                if (dropdownSpans.length >= 4) {
+                    dropdownSpans[0].textContent = t.profile;
+                    dropdownSpans[1].textContent = t.settings;
+                    dropdownSpans[2].textContent = t.privacy;
+                    dropdownSpans[3].textContent = t.logout;
+                }
+            }
+
+            const langToggle = document.getElementById('langToggle');
+            let currentLang = localStorage.getItem('finx_lang') || 'es';
+            setLanguage(currentLang);
+
+            if (langToggle) {
+                langToggle.addEventListener('click', function () {
+                    currentLang = currentLang === 'es' ? 'en' : 'es';
+                    setLanguage(currentLang);
+                });
+            }
+        });
+    </script>
+</body>
+</html>

--- a/chatbot.html
+++ b/chatbot.html
@@ -819,6 +819,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="calculadora-salario.html">
+                        <i class="bi bi-calculator-fill"></i>
+                        <span>Salary Calculator</span>
+                    </a>
+                </li>
+                <li>
                     <a href="helpcenter2.html">
                         <i class="bi bi-question-circle-fill"></i>
                         <span>Help</span>

--- a/css/calculadora-salario.css
+++ b/css/calculadora-salario.css
@@ -1,0 +1,585 @@
+/* FINX — Calculadora de Salario Neto
+   Estilos alineados con la paleta y tipografía del proyecto */
+
+.salary-page {
+    padding: 0.5rem 0 2.5rem;
+    min-height: auto;
+}
+
+.salary-hero {
+    text-align: center;
+    margin-bottom: 2.5rem;
+    padding: 2rem 1rem 1rem;
+}
+
+.salary-hero .badge-finx {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(29, 72, 138, 0.1);
+    color: var(--finx-deep-blue, #1D488A);
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.salary-hero h1 {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    color: var(--finx-blue-dark, #083066);
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    margin-bottom: 0.75rem;
+}
+
+.salary-hero .lead {
+    max-width: 640px;
+    margin: 0 auto;
+    color: var(--light-text, #5A7294);
+    font-size: 1.05rem;
+}
+
+.salary-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+}
+
+@media (min-width: 992px) {
+    .salary-layout {
+        grid-template-columns: 1.05fr 0.95fr;
+        align-items: start;
+    }
+}
+
+.salary-card {
+    background: var(--background-color, #fff);
+    border-radius: 18px;
+    box-shadow: var(--card-shadow);
+    border: 1px solid rgba(29, 72, 138, 0.08);
+    padding: 1.75rem;
+    transition: box-shadow 0.3s ease;
+}
+
+.salary-card:hover {
+    box-shadow: var(--hover-shadow);
+}
+
+.salary-card h2 {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 1.25rem;
+    color: var(--finx-blue-dark, #083066);
+    margin-bottom: 0.35rem;
+}
+
+.salary-card .card-subtitle {
+    color: var(--light-text, #5A7294);
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+}
+
+.form-label {
+    font-weight: 600;
+    color: var(--text-color, #083066);
+    margin-bottom: 0.4rem;
+}
+
+.form-control,
+.form-select {
+    border-radius: 12px;
+    border: 1.5px solid rgba(29, 72, 138, 0.18);
+    padding: 0.7rem 0.95rem;
+    font-family: 'Montserrat', sans-serif;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-control:focus,
+.form-select:focus {
+    border-color: var(--finx-deep-blue, #1D488A);
+    box-shadow: 0 0 0 0.2rem rgba(29, 72, 138, 0.15);
+}
+
+.form-control.is-invalid,
+.form-select.is-invalid {
+    border-color: var(--danger-color, #dc3545);
+}
+
+.field-hint {
+    display: block;
+    margin-top: 0.3rem;
+    font-size: 0.82rem;
+    color: var(--light-text, #5A7294);
+}
+
+.field-error {
+    display: block;
+    min-height: 1.1rem;
+    margin-top: 0.25rem;
+    font-size: 0.82rem;
+    color: var(--danger-color, #dc3545);
+}
+
+.option-group {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.option-chip {
+    position: relative;
+}
+
+.option-chip input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.option-chip label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    min-height: 48px;
+    padding: 0.65rem 0.85rem;
+    border-radius: 12px;
+    border: 1.5px solid rgba(29, 72, 138, 0.18);
+    background: var(--light-background, #F4F7FB);
+    color: var(--text-color, #083066);
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.option-chip input:focus-visible + label {
+    outline: 2px solid var(--finx-deep-blue, #1D488A);
+    outline-offset: 2px;
+}
+
+.option-chip input:checked + label {
+    background: rgba(29, 72, 138, 0.12);
+    border-color: var(--finx-deep-blue, #1D488A);
+    color: var(--finx-blue-dark, #083066);
+    box-shadow: inset 0 0 0 1px var(--finx-deep-blue, #1D488A);
+}
+
+.decimo-panel {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(255, 222, 50, 0.12);
+    border: 1px dashed rgba(29, 72, 138, 0.25);
+}
+
+.decimo-panel[hidden] {
+    display: none !important;
+}
+
+.form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.btn-salary-primary,
+.btn-salary-secondary {
+    border-radius: 12px;
+    font-weight: 700;
+    padding: 0.75rem 1.25rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.btn-salary-primary {
+    background: var(--finx-blue-dark, #083066) !important;
+    border-color: var(--finx-blue-dark, #083066) !important;
+    color: #fff !important;
+    flex: 1 1 180px;
+}
+
+.btn-salary-primary:hover {
+    background: var(--finx-deep-blue, #1D488A) !important;
+    border-color: var(--finx-deep-blue, #1D488A) !important;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 18px rgba(8, 48, 102, 0.25);
+}
+
+.btn-salary-secondary {
+    background: transparent !important;
+    border: 2px solid var(--finx-deep-blue, #1D488A) !important;
+    color: var(--finx-deep-blue, #1D488A) !important;
+    flex: 1 1 120px;
+}
+
+.btn-salary-secondary:hover {
+    background: rgba(29, 72, 138, 0.08) !important;
+    transform: translateY(-2px);
+}
+
+/* Resultados */
+.results-section {
+    opacity: 0;
+    transform: translateY(16px);
+    transition: opacity 0.45s ease, transform 0.45s ease;
+}
+
+.results-section.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.results-section[hidden] {
+    display: none !important;
+}
+
+.net-highlight {
+    background: linear-gradient(145deg, #083066 0%, #1D488A 55%, #2a5fa8 100%);
+    color: #fff;
+    border-radius: 18px;
+    padding: 1.75rem 1.5rem;
+    text-align: center;
+    margin-bottom: 1.25rem;
+    box-shadow: 0 12px 28px rgba(8, 48, 102, 0.28);
+}
+
+.net-highlight .net-label {
+    font-size: 0.95rem;
+    opacity: 0.9;
+    margin-bottom: 0.35rem;
+}
+
+.net-highlight .net-value {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: clamp(1.9rem, 5vw, 2.6rem);
+    letter-spacing: -0.02em;
+    color: var(--finx-yellow, #FFDE32);
+}
+
+.net-highlight .net-note {
+    margin-top: 0.65rem;
+    font-size: 0.82rem;
+    opacity: 0.85;
+}
+
+.breakdown-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.25rem;
+}
+
+.breakdown-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid rgba(29, 72, 138, 0.1);
+}
+
+.breakdown-list li:last-child {
+    border-bottom: none;
+    font-weight: 800;
+    color: var(--finx-blue-dark, #083066);
+    padding-top: 1rem;
+}
+
+.breakdown-item {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--text-color, #083066);
+}
+
+.breakdown-item .emoji {
+    font-size: 1.1rem;
+    width: 1.5rem;
+    text-align: center;
+}
+
+.breakdown-value {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.deduction-value {
+    color: #b42318;
+}
+
+.summary-stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+}
+
+.stat-box {
+    background: var(--light-background, #F4F7FB);
+    border-radius: 14px;
+    padding: 0.9rem 1rem;
+    text-align: center;
+}
+
+.stat-box .stat-label {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--light-text, #5A7294);
+    margin-bottom: 0.25rem;
+}
+
+.stat-box .stat-value {
+    font-weight: 800;
+    color: var(--finx-blue-dark, #083066);
+    font-size: 1.05rem;
+}
+
+.conversion-note {
+    font-size: 0.85rem;
+    color: var(--light-text, #5A7294);
+    background: rgba(145, 169, 204, 0.18);
+    border-radius: 10px;
+    padding: 0.65rem 0.85rem;
+    margin-bottom: 1rem;
+}
+
+.conversion-note[hidden] {
+    display: none !important;
+}
+
+/* Barra visual */
+.salary-bar-wrap {
+    margin-bottom: 0.5rem;
+}
+
+.salary-bar-title {
+    font-weight: 700;
+    font-size: 0.95rem;
+    margin-bottom: 0.65rem;
+    color: var(--finx-blue-dark, #083066);
+}
+
+.salary-bar {
+    display: flex;
+    width: 100%;
+    height: 28px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: rgba(29, 72, 138, 0.08);
+}
+
+.salary-bar span {
+    display: block;
+    height: 100%;
+    min-width: 0;
+    transition: width 0.55s ease;
+}
+
+.bar-neto { background: #28a745; }
+.bar-css { background: #1D488A; }
+.bar-se { background: #17a2b8; }
+.bar-isr { background: #ffc107; }
+.bar-otros { background: #6c757d; }
+
+.bar-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem 1rem;
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
+    color: var(--light-text, #5A7294);
+}
+
+.bar-legend i {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 0.35rem;
+}
+
+.legend-neto { background: #28a745; }
+.legend-css { background: #1D488A; }
+.legend-se { background: #17a2b8; }
+.legend-isr { background: #ffc107; }
+.legend-otros { background: #6c757d; }
+
+.isr-explain {
+    margin-top: 1.25rem;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(29, 72, 138, 0.06);
+    border-left: 4px solid var(--finx-deep-blue, #1D488A);
+    font-size: 0.9rem;
+}
+
+.isr-explain h3 {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: var(--finx-blue-dark, #083066);
+}
+
+.isr-explain ul {
+    margin: 0.5rem 0 0;
+    padding-left: 1.1rem;
+}
+
+.disclaimer {
+    margin-top: 1rem;
+    font-size: 0.82rem;
+    color: var(--light-text, #5A7294);
+    line-height: 1.5;
+}
+
+/* Décimo resultados */
+.decimo-results {
+    margin-top: 1.25rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(29, 72, 138, 0.12);
+}
+
+.decimo-results[hidden] {
+    display: none !important;
+}
+
+.decimo-results h3 {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--finx-blue-dark, #083066);
+    margin-bottom: 0.5rem;
+}
+
+/* Sabías que */
+.tips-section {
+    margin-top: 2.5rem;
+}
+
+.tips-section h2 {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    color: var(--finx-blue-dark, #083066);
+    text-align: center;
+    margin-bottom: 0.5rem;
+}
+
+.tips-section .tips-intro {
+    text-align: center;
+    color: var(--light-text, #5A7294);
+    margin-bottom: 1.5rem;
+}
+
+.tips-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+@media (min-width: 768px) {
+    .tips-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.tip-card {
+    background: var(--background-color, #fff);
+    border-radius: 16px;
+    padding: 1.15rem 1.25rem;
+    border: 1px solid rgba(29, 72, 138, 0.08);
+    box-shadow: var(--card-shadow);
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+}
+
+.tip-card .tip-icon {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 222, 50, 0.35);
+    color: var(--finx-blue-dark, #083066);
+    font-size: 1.1rem;
+}
+
+.tip-card p {
+    margin: 0;
+    font-size: 0.92rem;
+    color: var(--text-color, #083066);
+    line-height: 1.45;
+}
+
+.finx-message {
+    margin-top: 1.5rem;
+    text-align: center;
+    padding: 1.25rem 1.5rem;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(29, 72, 138, 0.08), rgba(255, 222, 50, 0.18));
+    color: var(--finx-blue-dark, #083066);
+    font-weight: 600;
+    font-size: 0.98rem;
+}
+
+/* Dark mode */
+[data-bs-theme="dark"] .salary-hero h1,
+[data-bs-theme="dark"] .salary-card h2,
+[data-bs-theme="dark"] .form-label,
+[data-bs-theme="dark"] .breakdown-item,
+[data-bs-theme="dark"] .breakdown-list li:last-child,
+[data-bs-theme="dark"] .stat-box .stat-value,
+[data-bs-theme="dark"] .salary-bar-title,
+[data-bs-theme="dark"] .isr-explain h3,
+[data-bs-theme="dark"] .decimo-results h3,
+[data-bs-theme="dark"] .tips-section h2,
+[data-bs-theme="dark"] .tip-card p,
+[data-bs-theme="dark"] .finx-message {
+    color: var(--text-color, #F4F7FB);
+}
+
+[data-bs-theme="dark"] .salary-card,
+[data-bs-theme="dark"] .tip-card {
+    background: rgba(12, 61, 122, 0.55);
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-bs-theme="dark"] .option-chip label,
+[data-bs-theme="dark"] .stat-box,
+[data-bs-theme="dark"] .decimo-panel {
+    background: rgba(8, 48, 102, 0.55);
+    color: var(--text-color, #F4F7FB);
+}
+
+[data-bs-theme="dark"] .form-control,
+[data-bs-theme="dark"] .form-select {
+    background-color: rgba(8, 48, 102, 0.65);
+    color: #F4F7FB;
+    border-color: rgba(145, 169, 204, 0.35);
+}
+
+[data-bs-theme="dark"] .btn-salary-secondary {
+    color: #F4F7FB !important;
+    border-color: #91A9CC !important;
+}
+
+[data-bs-theme="dark"] .salary-hero .badge-finx {
+    background: rgba(145, 169, 204, 0.2);
+    color: #FFDE32;
+}
+
+@media (max-width: 575.98px) {
+    .salary-card {
+        padding: 1.25rem;
+    }
+
+    .summary-stats {
+        grid-template-columns: 1fr;
+    }
+
+    .option-group {
+        grid-template-columns: 1fr;
+    }
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -1075,6 +1075,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="calculadora-salario.html">
+                        <i class="bi bi-calculator-fill"></i>
+                        <span>Salary Calculator</span>
+                    </a>
+                </li>
+                <li>
                     <a href="helpcenter2.html">
                         <i class="bi bi-question-circle-fill"></i>
                         <span>Help</span>
@@ -1671,7 +1677,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 'privacy': 'Privacidad',
                 'welcome-to': 'Bienvenido a',
                 'track-manage': '¡Registra, gestiona y ahorra fácilmente!',
-                'financial-assistant': 'Asistente Financiero'
+                'financial-assistant': 'Asistente Financiero',
+                'salary-calculator': 'Calculadora'
             },
             en: {
                 'dashboard-lead': 'Visualize and control your finances in a modern and fun way.',
@@ -1723,18 +1730,23 @@ document.addEventListener('DOMContentLoaded', function() {
                 'privacy': 'Privacy',
                 'welcome-to': 'Welcome to',
                 'track-manage': 'Track, Manage, and Save with Ease!',
-                'financial-assistant': 'Assistant'
+                'financial-assistant': 'Assistant',
+                'salary-calculator': 'Salary Calculator'
             }
         };
         function setLanguage(lang) {
             localStorage.setItem('finx_lang', lang);
             // Navbar y sidebar
-            document.querySelector('.sidebar-nav a.active span').textContent = translations[lang]['management'];
-            document.querySelectorAll('.sidebar-nav li')[1].querySelector('span').textContent = translations[lang]['lessons'];
-            document.querySelectorAll('.sidebar-nav li')[2].querySelector('span').textContent = translations[lang]['achievements'];
-            document.querySelectorAll('.sidebar-nav li')[3].querySelector('span').textContent = translations[lang]['goals'];
-            document.querySelectorAll('.sidebar-nav li')[4].querySelector('span').textContent = translations[lang]['help'];
-            document.querySelectorAll('.sidebar-nav li')[5].querySelector('span').textContent = translations[lang]['financial-assistant'];
+            const sidebarSpans = document.querySelectorAll('.sidebar-nav li span');
+            if (sidebarSpans.length >= 7) {
+                sidebarSpans[0].textContent = translations[lang]['management'];
+                sidebarSpans[1].textContent = translations[lang]['lessons'];
+                sidebarSpans[2].textContent = translations[lang]['achievements'];
+                sidebarSpans[3].textContent = translations[lang]['goals'];
+                sidebarSpans[4].textContent = translations[lang]['salary-calculator'];
+                sidebarSpans[5].textContent = translations[lang]['help'];
+                sidebarSpans[6].textContent = translations[lang]['financial-assistant'];
+            }
             // Botón de logout del sidebar
             if (document.querySelector('.sidebar-logout-btn span')) {
                 document.querySelector('.sidebar-logout-btn span').textContent = translations[lang]['logout'];

--- a/goals.html
+++ b/goals.html
@@ -1628,6 +1628,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="calculadora-salario.html">
+                        <i class="bi bi-calculator-fill"></i>
+                        <span>Salary Calculator</span>
+                    </a>
+                </li>
+                <li>
                     <a href="helpcenter2.html">
                         <i class="bi bi-question-circle-fill"></i>
                         <span>Help</span>

--- a/helpcenter2.html
+++ b/helpcenter2.html
@@ -807,6 +807,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="calculadora-salario.html">
+                        <i class="bi bi-calculator-fill"></i>
+                        <span>Salary Calculator</span>
+                    </a>
+                </li>
+                <li>
                     <a href="helpcenter2.html" class="active">
                         <i class="bi bi-question-circle-fill"></i>
                         <span>Help</span>

--- a/js/calculadora-salario.js
+++ b/js/calculadora-salario.js
@@ -1,0 +1,374 @@
+/**
+ * FINX — Calculadora de Salario Neto (Panamá)
+ * Fórmulas referenciales. Las tasas están centralizadas para facilitar actualizaciones.
+ */
+
+/* =========================
+   CONSTANTES DE TASAS / LÍMITES
+   ========================= */
+const TASA_CSS = 0.0975;
+const TASA_SEGURO_EDUCATIVO = 0.0125;
+const LIMITE_ISR_EXENTO = 11000;
+const LIMITE_ISR_15 = 50000;
+const TASA_ISR_15 = 0.15;
+const TASA_ISR_25 = 0.25;
+/** Monto fijo del tramo del 15% cuando el ingreso supera B/. 50,000: (50,000 - 11,000) × 0.15 */
+const ISR_FIJO_TRAMO_15 = 5850;
+const SALARIO_MAXIMO = 1000000;
+const MESES_ANIO = 12;
+
+/**
+ * NOTA SOBRE ISR:
+ * Se aplica la estructura progresiva 0% / 15% / 25% indicada en la especificación FINX.
+ * El sitio de referencia también muestra una tabla con un tramo del 30% sobre B/. 100,000.
+ * Esa diferencia no se aplica aquí de forma silenciosa: si la normativa oficial cambia,
+ * actualiza estas constantes. Esta herramienta es una estimación educativa.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('salaryForm');
+    const btnClear = document.getElementById('btnClear');
+    const frecuencia = document.getElementById('frecuencia');
+    const incluirDecimoSi = document.getElementById('incluirDecimoSi');
+    const incluirDecimoNo = document.getElementById('incluirDecimoNo');
+    const decimoOptions = document.getElementById('decimoOptions');
+    const salarioLabel = document.getElementById('salarioLabel');
+
+    if (!form) return;
+
+    frecuencia.addEventListener('change', actualizarEtiquetaSalario);
+    incluirDecimoSi.addEventListener('change', toggleDecimoOptions);
+    incluirDecimoNo.addEventListener('change', toggleDecimoOptions);
+    form.addEventListener('submit', onSubmit);
+    btnClear.addEventListener('click', limpiarFormulario);
+
+    actualizarEtiquetaSalario();
+    toggleDecimoOptions();
+});
+
+/* =========================
+   FUNCIONES DE CÁLCULO
+   ========================= */
+
+/**
+ * Convierte el salario ingresado a equivalente mensual.
+ * Quincenal → se multiplica × 2.
+ */
+function obtenerSalarioMensual(monto, frecuencia) {
+    const valor = Number(monto);
+    if (frecuencia === 'quincenal') {
+        return valor * 2;
+    }
+    return valor;
+}
+
+/** Seguro Social (CSS): 9.75% del salario bruto mensual */
+function calcularCSS(salarioBrutoMensual) {
+    return salarioBrutoMensual * TASA_CSS;
+}
+
+/** Seguro Educativo: 1.25% del salario bruto mensual */
+function calcularSeguroEducativo(salarioBrutoMensual) {
+    return salarioBrutoMensual * TASA_SEGURO_EDUCATIVO;
+}
+
+/**
+ * ISR anual estimado con estructura progresiva, luego se divide entre 12.
+ * - Hasta 11,000: 0%
+ * - De 11,000.01 a 50,000: 15% sobre el excedente de 11,000
+ * - Más de 50,000: 5,850 + 25% sobre el excedente de 50,000
+ */
+function calcularISR(salarioBrutoMensual) {
+    const ingresoAnual = salarioBrutoMensual * MESES_ANIO;
+    let isrAnual = 0;
+
+    if (ingresoAnual <= LIMITE_ISR_EXENTO) {
+        isrAnual = 0;
+    } else if (ingresoAnual <= LIMITE_ISR_15) {
+        isrAnual = (ingresoAnual - LIMITE_ISR_EXENTO) * TASA_ISR_15;
+    } else {
+        isrAnual = ISR_FIJO_TRAMO_15 + (ingresoAnual - LIMITE_ISR_15) * TASA_ISR_25;
+    }
+
+    return {
+        ingresoAnual,
+        isrAnual,
+        isrMensual: isrAnual / MESES_ANIO
+    };
+}
+
+/**
+ * Salario neto = bruto − CSS − Seguro Educativo − ISR mensual − otros descuentos
+ */
+function calcularSalarioNeto(salarioBruto, css, seguroEducativo, isrMensual, otrosDescuentos) {
+    return salarioBruto - css - seguroEducativo - isrMensual - otrosDescuentos;
+}
+
+/**
+ * Décimo tercer mes estimado.
+ * Bruto = salario acumulado del período / 12.
+ * Deducciones típicas sobre el décimo: CSS + Seguro Educativo (no se asume ISR).
+ */
+function calcularDecimo(salarioAcumuladoPeriodo) {
+    const decimoBruto = salarioAcumuladoPeriodo / MESES_ANIO;
+    const cssDecimo = calcularCSS(decimoBruto);
+    const seDecimo = calcularSeguroEducativo(decimoBruto);
+    const totalDeducciones = cssDecimo + seDecimo;
+    const decimoNeto = decimoBruto - totalDeducciones;
+
+    return {
+        decimoBruto,
+        cssDecimo,
+        seDecimo,
+        totalDeducciones,
+        decimoNeto
+    };
+}
+
+/* =========================
+   UI / VALIDACIÓN
+   ========================= */
+
+function actualizarEtiquetaSalario() {
+    const frecuencia = document.getElementById('frecuencia').value;
+    const label = document.getElementById('salarioLabel');
+    const hint = document.getElementById('salarioHint');
+
+    if (frecuencia === 'quincenal') {
+        label.textContent = 'Salario bruto quincenal (B/.)';
+        hint.textContent = 'Ingresa lo que ganas cada quincena. Se convertirá a equivalente mensual (× 2) para los cálculos.';
+    } else {
+        label.textContent = 'Salario bruto mensual (B/.)';
+        hint.textContent = 'Ingresa tu salario bruto antes de deducciones.';
+    }
+}
+
+function toggleDecimoOptions() {
+    const incluir = document.getElementById('incluirDecimoSi').checked;
+    const panel = document.getElementById('decimoOptions');
+    panel.hidden = !incluir;
+    panel.setAttribute('aria-hidden', incluir ? 'false' : 'true');
+}
+
+function limpiarErrores() {
+    document.querySelectorAll('.field-error').forEach((el) => {
+        el.textContent = '';
+    });
+    document.querySelectorAll('.is-invalid').forEach((el) => {
+        el.classList.remove('is-invalid');
+    });
+}
+
+function mostrarError(inputId, mensaje) {
+    const input = document.getElementById(inputId);
+    const errorEl = document.getElementById(`error-${inputId}`);
+    if (input) input.classList.add('is-invalid');
+    if (errorEl) errorEl.textContent = mensaje;
+}
+
+function validarFormulario() {
+    limpiarErrores();
+    let valido = true;
+
+    const salarioInput = document.getElementById('salarioBruto');
+    const salarioRaw = salarioInput.value.trim();
+    const salario = Number(salarioRaw);
+    const otrosRaw = document.getElementById('otrosDescuentos').value.trim();
+    const otros = otrosRaw === '' ? 0 : Number(otrosRaw);
+
+    if (salarioRaw === '' || Number.isNaN(salario)) {
+        mostrarError('salarioBruto', 'Ingresa un salario válido.');
+        valido = false;
+    } else if (salario <= 0) {
+        mostrarError('salarioBruto', 'El salario debe ser mayor que cero.');
+        valido = false;
+    } else if (salario > SALARIO_MAXIMO) {
+        mostrarError('salarioBruto', `El valor supera el límite permitido (B/. ${SALARIO_MAXIMO.toLocaleString('es-PA')}).`);
+        valido = false;
+    }
+
+    if (otrosRaw !== '') {
+        if (Number.isNaN(otros) || otros < 0) {
+            mostrarError('otrosDescuentos', 'Los descuentos voluntarios no pueden ser negativos.');
+            valido = false;
+        } else if (otros > SALARIO_MAXIMO) {
+            mostrarError('otrosDescuentos', 'El descuento voluntario es demasiado alto.');
+            valido = false;
+        }
+    }
+
+    if (document.getElementById('incluirDecimoSi').checked) {
+        const acumuladoRaw = document.getElementById('salarioAcumulado').value.trim();
+        const acumulado = Number(acumuladoRaw);
+        if (acumuladoRaw === '' || Number.isNaN(acumulado)) {
+            mostrarError('salarioAcumulado', 'Indica el salario acumulado del período para estimar el décimo.');
+            valido = false;
+        } else if (acumulado <= 0) {
+            mostrarError('salarioAcumulado', 'El salario acumulado debe ser mayor que cero.');
+            valido = false;
+        } else if (acumulado > SALARIO_MAXIMO * MESES_ANIO) {
+            mostrarError('salarioAcumulado', 'El acumulado ingresado es demasiado alto.');
+            valido = false;
+        }
+    }
+
+    return valido;
+}
+
+function onSubmit(event) {
+    event.preventDefault();
+    if (!validarFormulario()) {
+        const firstInvalid = document.querySelector('.is-invalid');
+        if (firstInvalid) firstInvalid.focus();
+        return;
+    }
+
+    const frecuencia = document.getElementById('frecuencia').value;
+    const salarioIngresado = Number(document.getElementById('salarioBruto').value);
+    const otrosDescuentos = document.getElementById('otrosDescuentos').value.trim() === ''
+        ? 0
+        : Number(document.getElementById('otrosDescuentos').value);
+    const salarioMensual = obtenerSalarioMensual(salarioIngresado, frecuencia);
+
+    const css = calcularCSS(salarioMensual);
+    const seguroEducativo = calcularSeguroEducativo(salarioMensual);
+    const isr = calcularISR(salarioMensual);
+    const salarioNeto = calcularSalarioNeto(
+        salarioMensual,
+        css,
+        seguroEducativo,
+        isr.isrMensual,
+        otrosDescuentos
+    );
+
+    const totalDeducciones = css + seguroEducativo + isr.isrMensual + otrosDescuentos;
+    const porcentajeDeducciones = salarioMensual > 0
+        ? (totalDeducciones / salarioMensual) * 100
+        : 0;
+
+    let decimo = null;
+    if (document.getElementById('incluirDecimoSi').checked) {
+        const acumulado = Number(document.getElementById('salarioAcumulado').value);
+        decimo = calcularDecimo(acumulado);
+    }
+
+    mostrarResultados({
+        salarioIngresado,
+        frecuencia,
+        salarioMensual,
+        css,
+        seguroEducativo,
+        isr,
+        otrosDescuentos,
+        salarioNeto,
+        totalDeducciones,
+        porcentajeDeducciones,
+        decimo
+    });
+}
+
+function limpiarFormulario() {
+    const form = document.getElementById('salaryForm');
+    form.reset();
+    limpiarErrores();
+    actualizarEtiquetaSalario();
+    toggleDecimoOptions();
+
+    const results = document.getElementById('resultsSection');
+    results.hidden = true;
+    results.classList.remove('is-visible');
+    document.getElementById('decimoResults').hidden = true;
+
+    document.getElementById('salarioBruto').focus();
+}
+
+/* =========================
+   RENDER DE RESULTADOS
+   ========================= */
+
+function formatMoney(valor) {
+    const num = Number(valor);
+    const formatted = num.toLocaleString('es-PA', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+    return `B/. ${formatted}`;
+}
+
+function formatPercent(valor) {
+    return `${Number(valor).toLocaleString('es-PA', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    })}%`;
+}
+
+function mostrarResultados(data) {
+    const results = document.getElementById('resultsSection');
+    results.hidden = false;
+
+    // Forzar reflow para animación
+    void results.offsetWidth;
+    results.classList.add('is-visible');
+
+    document.getElementById('netSalaryValue').textContent = formatMoney(data.salarioNeto);
+    document.getElementById('resultBruto').textContent = formatMoney(data.salarioMensual);
+    document.getElementById('resultCSS').textContent = `− ${formatMoney(data.css)}`;
+    document.getElementById('resultSE').textContent = `− ${formatMoney(data.seguroEducativo)}`;
+    document.getElementById('resultISR').textContent = `− ${formatMoney(data.isr.isrMensual)}`;
+    document.getElementById('resultOtros').textContent = `− ${formatMoney(data.otrosDescuentos)}`;
+    document.getElementById('resultNeto').textContent = formatMoney(data.salarioNeto);
+    document.getElementById('totalDeducciones').textContent = formatMoney(data.totalDeducciones);
+    document.getElementById('porcentajeDeducciones').textContent = formatPercent(data.porcentajeDeducciones);
+
+    // Detalle ISR
+    document.getElementById('isrIngresoAnual').textContent = formatMoney(data.isr.ingresoAnual);
+    document.getElementById('isrAnual').textContent = formatMoney(data.isr.isrAnual);
+    document.getElementById('isrMensualDetalle').textContent = formatMoney(data.isr.isrMensual);
+
+    if (data.frecuencia === 'quincenal') {
+        document.getElementById('conversionNote').hidden = false;
+        document.getElementById('conversionNote').textContent =
+            `Salario quincenal ingresado: ${formatMoney(data.salarioIngresado)} → equivalente mensual: ${formatMoney(data.salarioMensual)}.`;
+    } else {
+        document.getElementById('conversionNote').hidden = true;
+    }
+
+    actualizarBarra(data);
+    actualizarDecimoUI(data.decimo);
+
+    results.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function actualizarBarra(data) {
+    const total = data.salarioMensual;
+    const segments = [
+        { id: 'barNeto', value: Math.max(data.salarioNeto, 0) },
+        { id: 'barCSS', value: data.css },
+        { id: 'barSE', value: data.seguroEducativo },
+        { id: 'barISR', value: data.isr.isrMensual },
+        { id: 'barOtros', value: data.otrosDescuentos }
+    ];
+
+    segments.forEach(({ id, value }) => {
+        const el = document.getElementById(id);
+        const pct = total > 0 ? (value / total) * 100 : 0;
+        el.style.width = `${Math.max(pct, 0)}%`;
+        el.setAttribute('aria-valuenow', pct.toFixed(2));
+        el.title = `${pct.toFixed(2)}%`;
+    });
+}
+
+function actualizarDecimoUI(decimo) {
+    const section = document.getElementById('decimoResults');
+    if (!decimo) {
+        section.hidden = true;
+        return;
+    }
+
+    section.hidden = false;
+    document.getElementById('decimoBruto').textContent = formatMoney(decimo.decimoBruto);
+    document.getElementById('decimoCSS').textContent = `− ${formatMoney(decimo.cssDecimo)}`;
+    document.getElementById('decimoSE').textContent = `− ${formatMoney(decimo.seDecimo)}`;
+    document.getElementById('decimoDeducciones').textContent = formatMoney(decimo.totalDeducciones);
+    document.getElementById('decimoNeto').textContent = formatMoney(decimo.decimoNeto);
+}

--- a/js/components.js
+++ b/js/components.js
@@ -131,13 +131,56 @@ function addChatbotButtonToSidebars() {
     });
 }
 
+/**
+ * Agrega el enlace a la Calculadora de Salario Neto en las barras laterales.
+ * Resuelve la ruta relativa según si la página está en /trivia/ o en la raíz.
+ */
+function addSalaryCalculatorToSidebars() {
+    const sidebars = [
+        ...document.querySelectorAll('.trivia-sidebar, .leccion-sidebar, .camino-sidebar')
+    ];
+    const inTrivia = window.location.pathname.includes('/trivia/');
+    const calculatorHref = inTrivia ? '../calculadora-salario.html' : 'calculadora-salario.html';
+    const isActive = window.location.pathname.includes('calculadora-salario.html');
+
+    const calculatorMenuItemHTML = `
+        <li>
+            <a href="${calculatorHref}" class="${isActive ? 'active' : ''}">
+                <i class="bi bi-calculator-fill"></i>
+                <span>Salary Calculator</span>
+            </a>
+        </li>
+    `;
+
+    sidebars.forEach((sidebar) => {
+        const navMenu = sidebar.querySelector('.sidebar-nav');
+        if (!navMenu) return;
+
+        const alreadyExists = sidebar.querySelector('a[href*="calculadora-salario.html"]');
+        if (alreadyExists) return;
+
+        const logoutContainer = sidebar.querySelector('.sidebar-logout-container');
+        const helpLink = sidebar.querySelector('a[href*="helpcenter"], a[href*="Help_center"]');
+        const helpItem = helpLink ? helpLink.closest('li') : null;
+
+        if (helpItem) {
+            helpItem.insertAdjacentHTML('beforebegin', calculatorMenuItemHTML);
+        } else if (logoutContainer) {
+            logoutContainer.insertAdjacentHTML('beforebegin', calculatorMenuItemHTML);
+        } else {
+            navMenu.insertAdjacentHTML('beforeend', calculatorMenuItemHTML);
+        }
+    });
+}
+
 // Cargar componentes cuando el DOM esté listo
 document.addEventListener('DOMContentLoaded', () => {
     // Cargar header y footer si existen los elementos
     const headerElement = document.getElementById('header');
     
-    // Añadir botón del chatbot a las barras laterales
+    // Añadir botón del chatbot y calculadora a las barras laterales
     addChatbotButtonToSidebars();
+    addSalaryCalculatorToSidebars();
     const footerElement = document.getElementById('footer');
     const headerDashboardElement = document.getElementById('header_dashboard');
     const chatbotContainer = document.getElementById('chatbot-container');
@@ -171,6 +214,7 @@ const finxTranslations = {
         // Navbar
         'home': 'Home',
         'about-us': 'About us',
+        'salary-calculator': 'Net Salary Calculator',
         'help-center': 'Help center',
         'register': 'Register',
         'login': 'Login',
@@ -265,6 +309,7 @@ const finxTranslations = {
         // Navbar
         'home': 'Inicio',
         'about-us': 'Sobre nosotros',
+        'salary-calculator': 'Calculadora de salario',
         'help-center': 'Centro de ayuda',
         'register': 'Registrar',
         'login': 'Iniciar sesión',

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -1855,6 +1855,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="../calculadora-salario.html">
+                        <i class="bi bi-calculator-fill"></i>
+                        <span>Salary Calculator</span>
+                    </a>
+                </li>
+                <li>
                     <a href="../helpcenter2.html">
                         <i class="bi bi-question-circle-fill"></i>
                         <span>Help</span>
@@ -1908,6 +1914,12 @@
                     <a href="../goals.html">
                         <i class="bi bi-flag-fill"></i>
                         <span>Goals</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="../calculadora-salario.html">
+                        <i class="bi bi-calculator-fill"></i>
+                        <span>Salary Calculator</span>
                     </a>
                 </li>
                 <li>


### PR DESCRIPTION
- Added a new "Salary Calculator" link to the sidebar navigation in chatbot.html, dashboard.html, goals.html, helpcenter2.html, and trivia.html.
- Implemented a function to dynamically add the Salary Calculator link to sidebars based on the current page context.
- Updated translation keys for the Salary Calculator in both English and Spanish to enhance multilingual support.